### PR TITLE
Fixed message height for multi lines.

### DIFF
--- a/GSMessages/GSMessage.swift
+++ b/GSMessages/GSMessage.swift
@@ -370,7 +370,7 @@ public class GSMessage: NSObject {
         var textSize: CGSize = .zero
         
         if let attrText = messageText.attributedText {
-            let size = CGSize(width: textWidth / 2, height: 999)
+            let size = CGSize(width: textWidth, height: 999)
             let framesetter = CTFramesetterCreateWithAttributedString(attrText)
             textSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRange(), nil, size, nil)
         }


### PR DESCRIPTION
Not sure what's up with the logic behind this line of code. Why divide the textWidth by 2 here? 

Here is an example of a single line message **with** _and_ **without** the `/2` added. As you can see, the reduced width calculation results in an inaccurate (i.e. over-inflated) height. 

My use of the API is pretty straightforward (default padding and margins):
```
        self.showMessage(message, type: .success, options: [
            .animations([.slide(.normal)]),
            .animationDuration(0.3),
            .autoHide(true),
            .autoHideDelay(2.0),
            .hideOnTap(true),
            .position(.top),
            .textAlignment(.center),
            .textColor(UIColor.preferredColor(forPreferredColorType: .messageText)),
            .textNumberOfLines(0)
        ])
```

<img width="1668" alt="message-bug" src="https://user-images.githubusercontent.com/358709/89693962-fe4efb00-d8c4-11ea-84d7-58e51846e86d.png">

