### PR TITLE
Update for Xcode 12.

### DIFF
--- a/GSMessages.podspec
+++ b/GSMessages.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GSMessages"
-  s.version      = "1.7.4"
+  s.version      = "1.7.5"
   s.summary      = "A simple style messages/notifications, in Swift."
   s.homepage     = "https://github.com/wxxsw/GSMessages"
 
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Gesen" => "i@gesen.me" }
   s.source       = { :git => "https://github.com/wxxsw/GSMessages.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
 
   s.source_files = 'GSMessages'

--- a/GSMessages.xcodeproj/project.pbxproj
+++ b/GSMessages.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GSMessages/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = me.gesen.GSMessages;
@@ -289,7 +289,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GSMessages/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = me.gesen.GSMessages;

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
   name: "GSMessages",
   platforms: [
-    .iOS(.v8),
+    .iOS(.v9),
   ],
   products: [
     .library(name: "GSMessages", targets: ["GSMessages"])


### PR DESCRIPTION
This PR updates the whole project to be able to build on Xcode 12 without warnings by dropping iOS 8 support, also updates version to '1.7.5', which bumps the patch version.

`pod spec lint` has been performed without any errors.